### PR TITLE
chore: バージョンを 0.1.2 に変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/code-security",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "description": "Code security analyzer powered by acorn",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- 0.1.0 と 0.1.1 の npm パッケージ内容が同一だった問題に対応
- バージョンを 0.1.2 に変更（publish 時に `prepublishOnly` で最新コードがビルドされる）

🤖 Generated with [Claude Code](https://claude.com/claude-code)