### PR TITLE
fix: バンドル依存ファイルの技術的違反を完全抑制に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,9 @@ const result = service.validate({
 |-------------|----------|----------|
 | ユーザーコード | `__federation_expose_World-*.js` | 調整なし（すべて厳格） |
 | MF 動的インポート | `__federation_fn_import` を含む | 調整なし（すべて厳格） |
-| 共有ライブラリ | `__federation_shared_*` | 技術的違反を `warning` に緩和 |
-| バンドル依存 | 上記以外の `.js` | 技術的違反を `warning` に緩和 |
-| `remoteEntry.js` | ファイル名が一致 | `no-global-override` / `no-dangerous-dom` を完全抑制、他の技術的違反は `warning` |
+| 共有ライブラリ | `__federation_shared_*` | 技術的違反を完全抑制 |
+| バンドル依存 | 上記以外の `.js` | 技術的違反を完全抑制 |
+| `remoteEntry.js` | ファイル名が一致 | 技術的違反を完全抑制 |
 | Vite preload-helper | `preload-helper*` で始まる | `no-dangerous-dom` を完全抑制 |
 
 > **技術的違反**: `no-obfuscation`, `no-dangerous-dom`, `no-navigator-access`, `no-prototype-pollution`, `no-global-override`, `no-network-without-permission`

--- a/__tests__/analyzer.test.ts
+++ b/__tests__/analyzer.test.ts
@@ -511,4 +511,46 @@ describe('adjustViolationSeverity - ファイルコンテキスト別の抑制',
       expect(result).toBe('critical')
     })
   })
+
+  describe('バンドル依存ファイルの技術的違反は完全抑制される', () => {
+    const bundledContext: FileContext = {
+      filePath: 'vision_bundle-DJzU6HDp.js',
+      isUserCode: false,
+      isSharedLibrary: false,
+      isBundledDependency: true,
+    }
+
+    it.each([
+      'no-obfuscation',
+      'no-dangerous-dom',
+      'no-navigator-access',
+      'no-prototype-pollution',
+      'no-global-override',
+      'no-network-without-permission',
+    ])('%s は完全抑制される', (rule) => {
+      const result = adjustViolationSeverity(rule, 'critical', bundledContext)
+      expect(result).toBeNull()
+    })
+
+    it.each([
+      'no-eval',
+      'no-storage-access',
+      'no-storage-event',
+    ])('%s は critical のまま残る', (rule) => {
+      const result = adjustViolationSeverity(rule, 'critical', bundledContext)
+      expect(result).toBe('critical')
+    })
+
+    it('ユーザーコードでは技術的違反も抑制されない', () => {
+      const userContext: FileContext = {
+        filePath: '__federation_expose_World-abc123.js',
+        isUserCode: true,
+        isSharedLibrary: false,
+        isBundledDependency: false,
+      }
+
+      const result = adjustViolationSeverity('no-obfuscation', 'critical', userContext)
+      expect(result).toBe('critical')
+    })
+  })
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/code-security",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "description": "Code security analyzer powered by acorn",
   "main": "./dist/index.js",

--- a/src/utils/file-context.ts
+++ b/src/utils/file-context.ts
@@ -76,7 +76,8 @@ export function adjustViolationSeverity(
     }
   }
 
-  // 共有ライブラリ、バンドル依存、remoteEntryは一部のルールを緩和
+  // 共有ライブラリ、バンドル依存、remoteEntryは技術的違反を完全抑制
+  // 開発者が修正できないバンドルコードの warning はノイズになるため
   if (context.isSharedLibrary || context.isBundledDependency || isRemoteEntry) {
     const technicalViolations = [
       'no-obfuscation',
@@ -88,7 +89,7 @@ export function adjustViolationSeverity(
     ]
 
     if (technicalViolations.includes(rule)) {
-      return 'warning'
+      return null
     }
 
     const criticalViolations = [
@@ -113,14 +114,14 @@ export function describeFileContext(context: FileContext): string {
     return 'ユーザーコード（最も厳格に検証）'
   }
   if (context.isSharedLibrary) {
-    return '共有ライブラリ（Module Federation自動生成、一部ルールを緩和）'
+    return '共有ライブラリ（Module Federation自動生成、技術的違反を抑制）'
   }
   if (context.isBundledDependency) {
-    return 'バンドルされた依存ライブラリ（技術的違反を緩和）'
+    return 'バンドルされた依存ライブラリ（技術的違反を抑制）'
   }
   const fileName = context.filePath
   if (fileName === 'remoteEntry.js') {
-    return 'Module Federationエントリーポイント（Module Federation自動生成、一部ルールを緩和）'
+    return 'Module Federationエントリーポイント（Module Federation自動生成、技術的違反を抑制）'
   }
   if (fileName.includes('__federation_fn_import')) {
     return 'Module Federation動的インポート（厳格に検証）'


### PR DESCRIPTION
## Summary
- バンドル依存・共有ライブラリ・remoteEntry.js の技術的違反を `warning` → 完全抑制（`null`）に変更
- 開発者が修正できないバンドルコードの warning はノイズになるため、REVIEW 判定を解消
- `no-eval` / `no-storage-access` / `no-storage-event` は引き続き critical のまま維持
- バージョンを 0.1.3 に変更

## 背景
MediaPipe (`vision_bundle`)、Rapier (`rapier`)等のバンドル済みライブラリで `btoa`/`atob`、`navigator` アクセス、`createElement('script')`、動的 `fetch` が warning として大量に表示され、REVIEW 判定となっていた。

## Test plan
- [x] 全 40 テストパス（新規 10 テスト追加）
- [x] バンドル依存の技術的違反6種が完全抑制されることを確認
- [x] ユーザーコードでは引き続き検出されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)