### PR TITLE
fix: エラーメッセージの設定ファイル名を xrift.json に修正

### DIFF
--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -840,7 +840,7 @@ export function analyzeCodeSecurity(
           signals.detectedViolations.push(createViolation(
             'no-network-without-permission',
             'critical',
-            `new ${node.callee.name}() によるネットワーク通信にはxrift.config.tsでの権限宣言が必要です`,
+            `new ${node.callee.name}() によるネットワーク通信にはxrift.jsonでの権限宣言が必要です`,
             node
           ))
         }
@@ -871,7 +871,7 @@ export function analyzeCodeSecurity(
         signals.detectedViolations.push(createViolation(
           'no-network-without-permission',
           'critical',
-          'new BroadcastChannel() による通信チャネルの使用にはxrift.config.tsでの権限宣言が必要です',
+          'new BroadcastChannel() による通信チャネルの使用にはxrift.jsonでの権限宣言が必要です',
           node
         ))
       }
@@ -1114,7 +1114,7 @@ export function analyzeCodeSecurity(
       signals.detectedViolations.push(createViolation(
         'no-network-without-permission',
         'critical',
-        'ネットワーク通信にはxrift.config.tsでの権限宣言が必要です'
+        'ネットワーク通信にはxrift.jsonでの権限宣言が必要です'
       ))
     }
   }


### PR DESCRIPTION
## Summary
- エラーメッセージ内の設定ファイル名が `xrift.config.ts` となっていたのを正しい `xrift.json` に修正
- 対象箇所: `src/analyzer.ts` 内のネットワーク通信関連の violation メッセージ 3箇所

## Test plan
- [x] `npm test` — 全 139 テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)